### PR TITLE
feat: Add Slack user status integration with consent and email mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Database
+DATABASE_URL=postgresql://username:password@localhost:5432/holiday_tracker
+
+# Slack Integration
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+
+# Cron Job Security
+CRON_SECRET=your-cron-secret-here
+
+# NextAuth.js
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=your-nextauth-secret-here
+
+# Google OAuth (for NextAuth.js)
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-toast": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "@slack/web-api": "^7.9.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
@@ -4309,6 +4310,59 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@slack/logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18.0.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.15.0.tgz",
+      "integrity": "sha512-livb1gyG3J8ATLBJ3KjZfjHpTRz9btY1m5cgNuXxWJbhwRB1Gwb8Ly6XLJm2Sy1W6h+vLgqIHg7IwKrF1C1Szg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.9.3.tgz",
+      "integrity": "sha512-xjnoldVJyoUe61Ltqjr2UVYBolcsTpp5ottqzSI3l41UCaJgHSHIOpGuYps+nhLFvDfGGpDGUeQ7BWiq3+ypqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.8.3",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -4528,6 +4582,12 @@
       "engines": {
         "node": ">= 0.12"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@types/shimmer": {
       "version": "1.2.0",
@@ -4785,7 +4845,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -4801,7 +4860,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
       "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -5335,7 +5393,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5676,7 +5733,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6046,7 +6102,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6528,7 +6583,6 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6565,7 +6619,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
       "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7077,7 +7130,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7335,6 +7387,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -8349,6 +8407,56 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -8807,7 +8915,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ps-tree": {
@@ -9206,6 +9313,15 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/retry-request": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@slack/web-api": "^7.9.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,47 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { users } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+import SlackSettingsForm from '@/components/settings/slack-settings-form';
+
+export default async function SettingsPage() {
+  const session = await getServerSession(authOptions);
+  
+  if (!session?.user?.email) {
+    redirect('/auth/signin');
+  }
+
+  const user = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, session.user.email))
+    .limit(1);
+
+  if (!user[0]) {
+    redirect('/auth/signin');
+  }
+
+  return (
+    <div className="container max-w-4xl mx-auto py-8">
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold">Settings</h1>
+          <p className="text-muted-foreground">
+            Manage your account settings and preferences
+          </p>
+        </div>
+        
+        <div className="space-y-6">
+          <SlackSettingsForm 
+            user={user[0]} 
+            userId={user[0].id}
+            currentSlackPresenceUpdate={user[0].slackPresenceUpdate}
+            currentSlackEmail={user[0].slackEmail}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/user-menu.tsx
+++ b/src/components/auth/user-menu.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { LogOut, User, Crown } from 'lucide-react';
+import { LogOut, User, Crown, Settings } from 'lucide-react';
 
 export default function UserMenu() {
   const { data: session } = useSession();
@@ -31,6 +31,12 @@ export default function UserMenu() {
   const handleAdminDashboard = () => {
     startTransition(() => {
       router.push('/admin');
+    });
+  };
+
+  const handleSettings = () => {
+    startTransition(() => {
+      router.push('/settings');
     });
   };
 
@@ -65,6 +71,10 @@ export default function UserMenu() {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handleSettings} disabled={isPending}>
+          <Settings className="mr-2 h-4 w-4" />
+          <span>{isPending ? 'Loading...' : 'Settings'}</span>
+        </DropdownMenuItem>
         <DropdownMenuItem onClick={handleAdminDashboard} disabled={isPending}>
           <Crown className="mr-2 h-4 w-4" />
           <span>{isPending ? 'Loading...' : 'Admin Dashboard'}</span>

--- a/src/components/settings/slack-settings-form.tsx
+++ b/src/components/settings/slack-settings-form.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Separator } from '@/components/ui/separator';
+import { useToast } from '@/hooks/use-toast';
+import { updateUserSlackSettings } from '@/app/actions';
+import { Loader2, CheckCircle, AlertCircle, Info } from 'lucide-react';
+
+interface SlackSettingsFormProps {
+  user: {
+    id: string;
+    name: string | null;
+    email: string;
+  };
+  userId: string;
+  currentSlackPresenceUpdate: boolean;
+  currentSlackEmail: string | null;
+}
+
+export default function SlackSettingsForm({ 
+  user, 
+  userId, 
+  currentSlackPresenceUpdate, 
+  currentSlackEmail 
+}: SlackSettingsFormProps) {
+  const [slackPresenceUpdate, setSlackPresenceUpdate] = useState(currentSlackPresenceUpdate);
+  const [slackEmail, setSlackEmail] = useState(currentSlackEmail || '');
+  const [isPending, startTransition] = useTransition();
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (slackPresenceUpdate && !slackEmail.trim()) {
+      toast({
+        title: 'Validation Error',
+        description: 'Please enter your Slack email address to enable status updates.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (slackEmail && !slackEmail.includes('@')) {
+      toast({
+        title: 'Validation Error',
+        description: 'Please enter a valid email address.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        const result = await updateUserSlackSettings(
+          userId,
+          slackPresenceUpdate,
+          slackPresenceUpdate ? slackEmail : null
+        );
+
+        if (result.success) {
+          toast({
+            title: 'Settings Updated',
+            description: 'Your Slack settings have been saved successfully.',
+          });
+          router.refresh();
+        } else {
+          toast({
+            title: 'Error',
+            description: result.error || 'Failed to update settings.',
+            variant: 'destructive',
+          });
+        }
+      } catch (error) {
+        toast({
+          title: 'Error',
+          description: 'An unexpected error occurred. Please try again.',
+          variant: 'destructive',
+        });
+      }
+    });
+  };
+
+  const handleSwitchChange = (checked: boolean) => {
+    setSlackPresenceUpdate(checked);
+    if (!checked) {
+      setSlackEmail('');
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CardTitle>Slack Integration</CardTitle>
+          <Badge variant="outline">Optional</Badge>
+        </div>
+        <CardDescription>
+          Configure how your holiday status appears in Slack
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription>
+            When enabled, your Slack status will automatically update when you start or end holidays. 
+            This helps keep your team informed about your availability.
+          </AlertDescription>
+        </Alert>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="slack-presence-update" className="text-base">
+                Update my Slack status
+              </Label>
+              <div className="text-sm text-muted-foreground">
+                Automatically set your Slack status when you&apos;re on holiday
+              </div>
+            </div>
+            <Switch
+              id="slack-presence-update"
+              checked={slackPresenceUpdate}
+              onCheckedChange={handleSwitchChange}
+            />
+          </div>
+
+          {slackPresenceUpdate && (
+            <>
+              <Separator />
+              <div className="space-y-2">
+                <Label htmlFor="slack-email">
+                  Slack Account Email
+                </Label>
+                <Input
+                  id="slack-email"
+                  type="email"
+                  placeholder="your.slack@company.com"
+                  value={slackEmail}
+                  onChange={(e) => setSlackEmail(e.target.value)}
+                  required={slackPresenceUpdate}
+                />
+                <p className="text-sm text-muted-foreground">
+                  Enter the email address associated with your Slack account. This is used to identify your Slack profile.
+                </p>
+              </div>
+
+              <Alert>
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                  <strong>What happens when this is enabled:</strong>
+                  <ul className="mt-2 space-y-1 text-sm">
+                    <li>• Your Slack status will show when you&apos;re on holiday (e.g., &quot;On vacation until Jul 15 🏖️&quot;)</li>
+                    <li>• Your presence will be set to &quot;away&quot; during your time off</li>
+                    <li>• Status will be automatically cleared when you return</li>
+                  </ul>
+                </AlertDescription>
+              </Alert>
+            </>
+          )}
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={isPending}>
+              {isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <CheckCircle className="mr-2 h-4 w-4" />
+                  Save Settings
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, text, date, timestamp, pgEnum, integer, primaryKey } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, date, timestamp, pgEnum, integer, primaryKey, boolean } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import type { AdapterAccount } from 'next-auth/adapters';
 
@@ -15,6 +15,8 @@ export const users = pgTable('users', {
   emailVerified: timestamp('emailVerified', { mode: 'date' }),
   image: varchar('image', { length: 500 }),
   role: roleEnum('role').notNull().default('member'),
+  slackPresenceUpdate: boolean('slack_presence_update').notNull().default(false),
+  slackEmail: varchar('slack_email', { length: 255 }),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -104,7 +104,6 @@ export async function clearSlackUserStatus(userId: string): Promise<boolean> {
 }
 
 export async function setSlackUserPresence(
-  userId: string,
   presence: 'auto' | 'away'
 ): Promise<boolean> {
   try {
@@ -115,7 +114,7 @@ export async function setSlackUserPresence(
     });
     
     if (response.ok) {
-      console.log(`Successfully set Slack presence to ${presence} for user ${userId}`);
+      console.log(`Successfully set Slack presence to ${presence} for authenticated user`);
       return true;
     }
     
@@ -205,7 +204,7 @@ export async function processSlackStatusUpdate(
         };
       }
       
-      await setSlackUserPresence(slackUserId, 'away');
+      await setSlackUserPresence('away');
       
       return { success: true };
     } else {
@@ -218,7 +217,7 @@ export async function processSlackStatusUpdate(
         };
       }
       
-      await setSlackUserPresence(slackUserId, 'auto');
+      await setSlackUserPresence('auto');
       
       return { success: true };
     }

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,5 +1,12 @@
 import { WebClient } from '@slack/web-api';
 
+interface SlackUserProfile {
+  status_text: string;
+  status_emoji: string;
+  status_expiration?: number;
+  [key: string]: unknown;
+}
+
 let slackClient: WebClient | null = null;
 
 function getSlackClient(): WebClient {
@@ -41,7 +48,7 @@ export async function updateSlackUserStatus(
   try {
     const client = getSlackClient();
     
-    const profile: any = {
+    const profile: SlackUserProfile = {
       status_text: statusText,
       status_emoji: statusEmoji,
     };
@@ -72,13 +79,15 @@ export async function clearSlackUserStatus(userId: string): Promise<boolean> {
   try {
     const client = getSlackClient();
     
+    const profile: SlackUserProfile = {
+      status_text: '',
+      status_emoji: '',
+      status_expiration: 0,
+    };
+    
     const response = await client.users.profile.set({
       user: userId,
-      profile: {
-        status_text: '',
-        status_emoji: '',
-        status_expiration: 0,
-      },
+      profile: profile,
     });
     
     if (response.ok) {

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,0 +1,223 @@
+import { WebClient } from '@slack/web-api';
+
+let slackClient: WebClient | null = null;
+
+function getSlackClient(): WebClient {
+  if (!slackClient) {
+    const token = process.env.SLACK_BOT_TOKEN;
+    if (!token) {
+      throw new Error('SLACK_BOT_TOKEN environment variable is not set');
+    }
+    slackClient = new WebClient(token);
+  }
+  return slackClient;
+}
+
+export async function lookupSlackUserByEmail(email: string): Promise<string | null> {
+  try {
+    const client = getSlackClient();
+    const response = await client.users.lookupByEmail({
+      email: email,
+    });
+    
+    if (response.ok && response.user) {
+      return response.user.id as string;
+    }
+    
+    console.error('Failed to lookup Slack user:', response.error);
+    return null;
+  } catch (error) {
+    console.error('Error looking up Slack user by email:', error);
+    return null;
+  }
+}
+
+export async function updateSlackUserStatus(
+  userId: string,
+  statusText: string,
+  statusEmoji: string = ':palm_tree:',
+  statusExpiration?: number
+): Promise<boolean> {
+  try {
+    const client = getSlackClient();
+    
+    const profile: any = {
+      status_text: statusText,
+      status_emoji: statusEmoji,
+    };
+    
+    if (statusExpiration) {
+      profile.status_expiration = statusExpiration;
+    }
+    
+    const response = await client.users.profile.set({
+      user: userId,
+      profile: profile,
+    });
+    
+    if (response.ok) {
+      console.log(`Successfully updated Slack status for user ${userId}`);
+      return true;
+    }
+    
+    console.error('Failed to update Slack status:', response.error);
+    return false;
+  } catch (error) {
+    console.error('Error updating Slack user status:', error);
+    return false;
+  }
+}
+
+export async function clearSlackUserStatus(userId: string): Promise<boolean> {
+  try {
+    const client = getSlackClient();
+    
+    const response = await client.users.profile.set({
+      user: userId,
+      profile: {
+        status_text: '',
+        status_emoji: '',
+        status_expiration: 0,
+      },
+    });
+    
+    if (response.ok) {
+      console.log(`Successfully cleared Slack status for user ${userId}`);
+      return true;
+    }
+    
+    console.error('Failed to clear Slack status:', response.error);
+    return false;
+  } catch (error) {
+    console.error('Error clearing Slack user status:', error);
+    return false;
+  }
+}
+
+export async function setSlackUserPresence(
+  userId: string,
+  presence: 'auto' | 'away'
+): Promise<boolean> {
+  try {
+    const client = getSlackClient();
+    
+    const response = await client.users.setPresence({
+      presence: presence,
+    });
+    
+    if (response.ok) {
+      console.log(`Successfully set Slack presence to ${presence} for user ${userId}`);
+      return true;
+    }
+    
+    console.error('Failed to set Slack presence:', response.error);
+    return false;
+  } catch (error) {
+    console.error('Error setting Slack user presence:', error);
+    return false;
+  }
+}
+
+export function getLeaveTypeStatusEmoji(leaveType: string): string {
+  switch (leaveType.toLowerCase()) {
+    case 'annual':
+    case 'vacation':
+      return ':palm_tree:';
+    case 'sick':
+      return ':face_with_thermometer:';
+    case 'personal':
+      return ':house:';
+    case 'maternity':
+      return ':baby:';
+    case 'paternity':
+      return ':man-baby:';
+    case 'public':
+      return ':calendar:';
+    default:
+      return ':calendar:';
+  }
+}
+
+export function formatStatusMessage(
+  leaveType: string,
+  endDate: string,
+  userName?: string
+): string {
+  const typeDisplayMap: { [key: string]: string } = {
+    annual: 'on vacation',
+    vacation: 'on vacation',
+    sick: 'out sick',
+    personal: 'out on personal leave',
+    maternity: 'on maternity leave',
+    paternity: 'on paternity leave',
+    public: 'out for public holiday',
+  };
+  
+  const typeText = typeDisplayMap[leaveType.toLowerCase()] || 'out of office';
+  const endDateFormatted = new Date(endDate).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+  
+  return `${typeText} until ${endDateFormatted}`;
+}
+
+export async function processSlackStatusUpdate(
+  userEmail: string,
+  slackEmail: string,
+  leaveType: string,
+  endDate: string,
+  isStarting: boolean = true
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const slackUserId = await lookupSlackUserByEmail(slackEmail);
+    
+    if (!slackUserId) {
+      return {
+        success: false,
+        error: `Could not find Slack user with email: ${slackEmail}`,
+      };
+    }
+    
+    if (isStarting) {
+      const statusEmoji = getLeaveTypeStatusEmoji(leaveType);
+      const statusText = formatStatusMessage(leaveType, endDate);
+      
+      const statusUpdated = await updateSlackUserStatus(
+        slackUserId,
+        statusText,
+        statusEmoji
+      );
+      
+      if (!statusUpdated) {
+        return {
+          success: false,
+          error: 'Failed to update Slack status',
+        };
+      }
+      
+      await setSlackUserPresence(slackUserId, 'away');
+      
+      return { success: true };
+    } else {
+      const statusCleared = await clearSlackUserStatus(slackUserId);
+      
+      if (!statusCleared) {
+        return {
+          success: false,
+          error: 'Failed to clear Slack status',
+        };
+      }
+      
+      await setSlackUserPresence(slackUserId, 'auto');
+      
+      return { success: true };
+    }
+  } catch (error) {
+    console.error('Error processing Slack status update:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error occurred',
+    };
+  }
+}


### PR DESCRIPTION
- Add slackPresenceUpdate and slackEmail fields to user schema
- Install @slack/web-api package for Slack Web API integration
- Create comprehensive Slack utility functions for status management
- Add settings page with user preferences for Slack integration
- Integrate status updates into holiday approval workflow
- Add daily cron job processing for holiday start/end status updates
- Implement user consent mechanism with email mapping
- Add environment variable configuration for SLACK_BOT_TOKEN
- Create professional UI components for Slack preferences
- Add Settings menu item to user dropdown navigation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack integration allowing users to enable automatic Slack status updates when their holiday requests are approved.
  * Introduced a settings page where users can manage their Slack presence preferences and provide their Slack email.
  * Slack status updates are processed automatically for holidays starting or ending each day.

* **Chores**
  * Added a template for environment variables including Slack and authentication settings.
  * Updated dependencies to include Slack Web API support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->